### PR TITLE
Updates DotNetDash to use newest version of NetworkTables

### DIFF
--- a/DotNetDash.LiveWindow/DotNetDash.LiveWindow.csproj
+++ b/DotNetDash.LiveWindow/DotNetDash.LiveWindow.csproj
@@ -30,12 +30,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FRC.NetworkTables, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\FRC.NetworkTables.3.0.0-beta-0054\lib\net46\FRC.NetworkTables.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Hellosam.Net.Collections, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\hellosam.net.collections.1.0.0\lib\net35-client\Hellosam.Net.Collections.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="NetworkTables, Version=2016.0.1.16, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\FRC.NetworkTables.2016.0.1.16\lib\net45\NetworkTables.dll</HintPath>
+    <Reference Include="Nito.AsyncEx.Coordination, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.Coordination.1.0.2\lib\net46\Nito.AsyncEx.Coordination.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.AsyncEx.Tasks, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.Tasks.1.0.1\lib\net46\Nito.AsyncEx.Tasks.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.Collections.Deque, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.Collections.Deque.1.0.0\lib\portable45-net45+win8+wp8+wpa81\Nito.Collections.Deque.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.Disposables, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.Disposables.1.0.0\lib\portable45-net45+win8+wp8+wpa81\Nito.Disposables.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />

--- a/DotNetDash.LiveWindow/RootTableContext.cs
+++ b/DotNetDash.LiveWindow/RootTableContext.cs
@@ -9,7 +9,7 @@ namespace DotNetDash.LiveWindow
         {
             statusTable = table.GetSubTable("~STATUS~");
             statusTable.AddTableListener("LW Enabled", (changedTable, _, value, flags) =>
-                Enabled = (bool)value, true);
+                Enabled = value.GetBoolean(), true);
         }
 
         private bool enabled;

--- a/DotNetDash.LiveWindow/packages.config
+++ b/DotNetDash.LiveWindow/packages.config
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FRC.NetworkTables" version="2016.0.1.16" targetFramework="net46" />
+  <package id="FRC.NetworkTables" version="3.0.0-beta-0054" targetFramework="net46" />
   <package id="hellosam.net.collections" version="1.0.0" targetFramework="net46" />
+  <package id="Nito.AsyncEx.Coordination" version="1.0.2" targetFramework="net46" />
+  <package id="Nito.AsyncEx.Tasks" version="1.0.1" targetFramework="net46" />
+  <package id="Nito.Collections.Deque" version="1.0.0" targetFramework="net46" />
+  <package id="Nito.Disposables" version="1.0.0" targetFramework="net46" />
   <package id="Serilog" version="1.5.14" targetFramework="net46" />
 </packages>

--- a/DotNetDash.SpeedController/DotNetDash.SpeedController.csproj
+++ b/DotNetDash.SpeedController/DotNetDash.SpeedController.csproj
@@ -30,8 +30,24 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NetworkTables, Version=2016.0.1.16, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\FRC.NetworkTables.2016.0.1.16\lib\net45\NetworkTables.dll</HintPath>
+    <Reference Include="FRC.NetworkTables, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\FRC.NetworkTables.3.0.0-beta-0054\lib\net46\FRC.NetworkTables.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.AsyncEx.Coordination, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.Coordination.1.0.2\lib\net46\Nito.AsyncEx.Coordination.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.AsyncEx.Tasks, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.Tasks.1.0.1\lib\net46\Nito.AsyncEx.Tasks.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.Collections.Deque, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.Collections.Deque.1.0.0\lib\portable45-net45+win8+wp8+wpa81\Nito.Collections.Deque.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.Disposables, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.Disposables.1.0.0\lib\portable45-net45+win8+wp8+wpa81\Nito.Disposables.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OxyPlot, Version=1.0.0.0, Culture=neutral, PublicKeyToken=638079a8f0bd61e9, processorArchitecture=MSIL">

--- a/DotNetDash.SpeedController/packages.config
+++ b/DotNetDash.SpeedController/packages.config
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FRC.NetworkTables" version="2016.0.1.16" targetFramework="net46" />
+  <package id="FRC.NetworkTables" version="3.0.0-beta-0054" targetFramework="net46" />
+  <package id="Nito.AsyncEx.Coordination" version="1.0.2" targetFramework="net46" />
+  <package id="Nito.AsyncEx.Tasks" version="1.0.1" targetFramework="net46" />
+  <package id="Nito.Collections.Deque" version="1.0.0" targetFramework="net46" />
+  <package id="Nito.Disposables" version="1.0.0" targetFramework="net46" />
   <package id="OxyPlot.Core" version="1.0.0-unstable1970" targetFramework="net46" />
   <package id="OxyPlot.Wpf" version="1.0.0-unstable1970" targetFramework="net46" />
 </packages>

--- a/DotNetDash.Test/DotNetDash.Test.csproj
+++ b/DotNetDash.Test/DotNetDash.Test.csproj
@@ -30,8 +30,24 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NetworkTables, Version=2016.0.1.16, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\FRC.NetworkTables.2016.0.1.16\lib\net45\NetworkTables.dll</HintPath>
+    <Reference Include="FRC.NetworkTables, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\FRC.NetworkTables.3.0.0-beta-0054\lib\net46\FRC.NetworkTables.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.AsyncEx.Coordination, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.Coordination.1.0.2\lib\net46\Nito.AsyncEx.Coordination.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.AsyncEx.Tasks, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.Tasks.1.0.1\lib\net46\Nito.AsyncEx.Tasks.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.Collections.Deque, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.Collections.Deque.1.0.0\lib\portable45-net45+win8+wp8+wpa81\Nito.Collections.Deque.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.Disposables, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.Disposables.1.0.0\lib\portable45-net45+win8+wp8+wpa81\Nito.Disposables.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">

--- a/DotNetDash.Test/MockTable.cs
+++ b/DotNetDash.Test/MockTable.cs
@@ -1,5 +1,4 @@
 ﻿using NetworkTables;
-using NetworkTables.Native;
 using NetworkTables.Tables;
 using System;
 using System.Collections.Generic;
@@ -10,14 +9,14 @@ namespace DotNetDash.Test
     {
         private class ActionTableListener : ITableListener
         {
-            private readonly Action<ITable, string, object, NotifyFlags> listenerDelegate;
+            private readonly Action<ITable, string, Value, NotifyFlags> listenerDelegate;
 
-            public ActionTableListener(Action<ITable, string, object, NotifyFlags> listenerDelegate)
+            public ActionTableListener(Action<ITable, string, Value, NotifyFlags> listenerDelegate)
             {
                 this.listenerDelegate = listenerDelegate;
             }
 
-            public void ValueChanged(ITable source, string key, object value, NotifyFlags flags)
+            public void ValueChanged(ITable source, string key, Value value, NotifyFlags flags)
             {
                 listenerDelegate(source, key, value, flags);
             }
@@ -30,7 +29,7 @@ namespace DotNetDash.Test
 
 
 
-        private void RaiseListeners(List<ITableListener> listeners, string key, object value, NotifyFlags flags)
+        private void RaiseListeners(List<ITableListener> listeners, string key, Value value, NotifyFlags flags)
         {
             foreach (var listener in listeners)
             {
@@ -39,9 +38,49 @@ namespace DotNetDash.Test
         }
 
 
-        public void AddSubTableListener(Action<ITable, string, object, NotifyFlags> listenerDelegate)
+        public void AddSubTableListener(Action<ITable, string, Value, NotifyFlags> listenerDelegate)
         {
             subtableListeners.Add(new ActionTableListener(listenerDelegate));
+        }
+
+        public bool SetDefaultValue(string key, Value defaultValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool SetDefaultNumber(string key, double defaultValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool SetDefaultBoolean(string key, bool defaultValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool SetDefaultString(string key, string defaultValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool SetDefaultRaw(string key, byte[] defaultValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool SetDefaultBooleanArray(string key, bool[] defaultValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool SetDefaultNumberArray(string key, double[] defaultValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool SetDefaultStringArray(string key, string[] defaultValue)
+        {
+            throw new NotImplementedException();
         }
 
         public void AddSubTableListener(ITableListener listener)
@@ -49,7 +88,7 @@ namespace DotNetDash.Test
             subtableListeners.Add(listener);
         }
 
-        public void AddSubTableListener(Action<ITable, string, object, NotifyFlags> listenerDelegate, bool localNotify)
+        public void AddSubTableListener(Action<ITable, string, Value, NotifyFlags> listenerDelegate, bool localNotify)
         {
             subtableListeners.Add(new ActionTableListener(listenerDelegate));
         }
@@ -59,7 +98,7 @@ namespace DotNetDash.Test
             subtableListeners.Add(listener);
         }
 
-        public void AddTableListener(Action<ITable, string, object, NotifyFlags> listenerDelegate, bool immediateNotify = false)
+        public void AddTableListener(Action<ITable, string, Value, NotifyFlags> listenerDelegate, bool immediateNotify = false)
         {
             tableListeners.Add(new ActionTableListener(listenerDelegate));
         }
@@ -69,7 +108,7 @@ namespace DotNetDash.Test
             tableListeners.Add(listener);
         }
 
-        public void AddTableListener(string key, Action<ITable, string, object, NotifyFlags> listenerDelegate, bool immediateNotify)
+        public void AddTableListener(string key, Action<ITable, string, Value, NotifyFlags> listenerDelegate, bool immediateNotify)
         {
             throw new NotImplementedException();
         }
@@ -79,7 +118,7 @@ namespace DotNetDash.Test
             throw new NotImplementedException();
         }
 
-        public void AddTableListenerEx(Action<ITable, string, object, NotifyFlags> listenerDelegate, NotifyFlags flags)
+        public void AddTableListenerEx(Action<ITable, string, Value, NotifyFlags> listenerDelegate, NotifyFlags flags)
         {
             tableListeners.Add(new ActionTableListener(listenerDelegate));
         }
@@ -89,7 +128,7 @@ namespace DotNetDash.Test
             throw new NotImplementedException();
         }
 
-        public void AddTableListenerEx(string key, Action<ITable, string, object, NotifyFlags> listenerDelegate, NotifyFlags flags)
+        public void AddTableListenerEx(string key, Action<ITable, string, Value, NotifyFlags> listenerDelegate, NotifyFlags flags)
         {
             throw new NotImplementedException();
         }
@@ -138,7 +177,7 @@ namespace DotNetDash.Test
             else
             {
                 storage[key] = defaultValue;
-                RaiseListeners(tableListeners, key, defaultValue, NotifyFlags.NotifyNew);
+                RaiseListeners(tableListeners, key, Value.MakeBoolean(defaultValue), NotifyFlags.NotifyNew);
                 return storage[key];
             }
         }
@@ -157,7 +196,7 @@ namespace DotNetDash.Test
             else
             {
                 storage[key] = defaultValue;
-                RaiseListeners(tableListeners, key, defaultValue, NotifyFlags.NotifyNew);
+                RaiseListeners(tableListeners, key, Value.MakeBooleanArray(defaultValue), NotifyFlags.NotifyNew);
                 return storage[key];
             }
         }
@@ -191,7 +230,7 @@ namespace DotNetDash.Test
             else
             {
                 storage[key] = defaultValue;
-                RaiseListeners(tableListeners, key, defaultValue, NotifyFlags.NotifyNew);
+                RaiseListeners(tableListeners, key, Value.MakeDouble(defaultValue), NotifyFlags.NotifyNew);
                 return storage[key];
             }
         }
@@ -210,7 +249,7 @@ namespace DotNetDash.Test
             else
             {
                 storage[key] = defaultValue;
-                RaiseListeners(tableListeners, key, defaultValue, NotifyFlags.NotifyNew);
+                RaiseListeners(tableListeners, key, Value.MakeDoubleArray(defaultValue), NotifyFlags.NotifyNew);
                 return storage[key];
             }
         }
@@ -239,7 +278,7 @@ namespace DotNetDash.Test
             else
             {
                 storage[key] = defaultValue;
-                RaiseListeners(tableListeners, key, defaultValue, NotifyFlags.NotifyNew);
+                RaiseListeners(tableListeners, key, Value.MakeString(defaultValue), NotifyFlags.NotifyNew);
                 return storage[key];
             }
         }
@@ -258,7 +297,7 @@ namespace DotNetDash.Test
             else
             {
                 storage[key] = defaultValue;
-                RaiseListeners(tableListeners, key, defaultValue, NotifyFlags.NotifyNew);
+                RaiseListeners(tableListeners, key, Value.MakeStringArray(defaultValue), NotifyFlags.NotifyNew);
                 return storage[key];
             }
         }
@@ -282,12 +321,12 @@ namespace DotNetDash.Test
             return new HashSet<string>(subTables.Keys);
         }
 
-        public object GetValue(string key)
+        public Value GetValue(string key)
         {
             return storage[key];
         }
 
-        public object GetValue(string key, object defaultValue)
+        public Value GetValue(string key, Value defaultValue)
         {
             if (storage.ContainsKey(key))
             {
@@ -309,28 +348,28 @@ namespace DotNetDash.Test
         public bool PutBoolean(string key, bool value)
         {
             storage[key] = value;
-            RaiseListeners(tableListeners, key, value, NotifyFlags.NotifyNew & NotifyFlags.NotifyUpdate);
+            RaiseListeners(tableListeners, key, Value.MakeBoolean(value), NotifyFlags.NotifyNew & NotifyFlags.NotifyUpdate);
             return true;
         }
 
         public bool PutBooleanArray(string key, bool[] value)
         {
             storage[key] = value;
-            RaiseListeners(tableListeners, key, value, NotifyFlags.NotifyNew & NotifyFlags.NotifyUpdate);
+            RaiseListeners(tableListeners, key, Value.MakeBooleanArray(value), NotifyFlags.NotifyNew & NotifyFlags.NotifyUpdate);
             return true;
         }
 
         public bool PutNumber(string key, double value)
         {
             storage[key] = value;
-            RaiseListeners(tableListeners, key, value, NotifyFlags.NotifyNew & NotifyFlags.NotifyUpdate);
+            RaiseListeners(tableListeners, key, Value.MakeDouble(value), NotifyFlags.NotifyNew & NotifyFlags.NotifyUpdate);
             return true;
         }
 
         public bool PutNumberArray(string key, double[] value)
         {
             storage[key] = value;
-            RaiseListeners(tableListeners, key, value, NotifyFlags.NotifyNew & NotifyFlags.NotifyUpdate);
+            RaiseListeners(tableListeners, key, Value.MakeDoubleArray(value), NotifyFlags.NotifyNew & NotifyFlags.NotifyUpdate);
             return true;
         }
 
@@ -342,25 +381,25 @@ namespace DotNetDash.Test
         public bool PutString(string key, string value)
         {
             storage[key] = value;
-            RaiseListeners(tableListeners, key, value, NotifyFlags.NotifyNew & NotifyFlags.NotifyUpdate);
+            RaiseListeners(tableListeners, key, Value.MakeString(value), NotifyFlags.NotifyNew & NotifyFlags.NotifyUpdate);
             return true;
         }
 
         public bool PutStringArray(string key, string[] value)
         {
             storage[key] = value;
-            RaiseListeners(tableListeners, key, value, NotifyFlags.NotifyNew & NotifyFlags.NotifyUpdate);
+            RaiseListeners(tableListeners, key, Value.MakeStringArray(value), NotifyFlags.NotifyNew & NotifyFlags.NotifyUpdate);
             return true;
         }
 
-        public bool PutValue(string key, object value)
+        public bool PutValue(string key, Value value)
         {
             storage[key] = value;
             RaiseListeners(tableListeners, key, value, NotifyFlags.NotifyNew & NotifyFlags.NotifyUpdate);
             return true;
         }
 
-        public void RemoveTableListener(Action<ITable, string, object, NotifyFlags> listenerDelegate)
+        public void RemoveTableListener(Action<ITable, string, Value, NotifyFlags> listenerDelegate)
         {
             throw new NotImplementedException();
         }

--- a/DotNetDash.Test/packages.config
+++ b/DotNetDash.Test/packages.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FRC.NetworkTables" version="2016.0.1.16" targetFramework="net46" />
+  <package id="FRC.NetworkTables" version="3.0.0-beta-0054" targetFramework="net46" />
+  <package id="Nito.AsyncEx.Coordination" version="1.0.2" targetFramework="net46" />
+  <package id="Nito.AsyncEx.Tasks" version="1.0.1" targetFramework="net46" />
+  <package id="Nito.Collections.Deque" version="1.0.0" targetFramework="net46" />
+  <package id="Nito.Disposables" version="1.0.0" targetFramework="net46" />
   <package id="NUnit" version="2.6.4" targetFramework="net46" />
 </packages>

--- a/DotNetDash/DotNetDash.csproj
+++ b/DotNetDash/DotNetDash.csproj
@@ -45,12 +45,28 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FRC.NetworkTables, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\FRC.NetworkTables.3.0.0-beta-0054\lib\net46\FRC.NetworkTables.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Hellosam.Net.Collections, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\hellosam.net.collections.1.0.0\lib\net35-client\Hellosam.Net.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NetworkTables, Version=2016.0.1.16, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\FRC.NetworkTables.2016.0.1.16\lib\net45\NetworkTables.dll</HintPath>
+    <Reference Include="Nito.AsyncEx.Coordination, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.Coordination.1.0.2\lib\net46\Nito.AsyncEx.Coordination.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.AsyncEx.Tasks, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.Tasks.1.0.1\lib\net46\Nito.AsyncEx.Tasks.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.Collections.Deque, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.Collections.Deque.1.0.0\lib\portable45-net45+win8+wp8+wpa81\Nito.Collections.Deque.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.Disposables, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.Disposables.1.0.0\lib\portable45-net45+win8+wp8+wpa81\Nito.Disposables.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">

--- a/DotNetDash/packages.config
+++ b/DotNetDash/packages.config
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FRC.NetworkTables" version="2016.0.1.16" targetFramework="net46" />
+  <package id="FRC.NetworkTables" version="3.0.0-beta-0054" targetFramework="net46" />
   <package id="hellosam.net.collections" version="1.0.0" targetFramework="net46" />
+  <package id="Nito.AsyncEx.Coordination" version="1.0.2" targetFramework="net46" />
+  <package id="Nito.AsyncEx.Tasks" version="1.0.1" targetFramework="net46" />
+  <package id="Nito.Collections.Deque" version="1.0.0" targetFramework="net46" />
+  <package id="Nito.Disposables" version="1.0.0" targetFramework="net46" />
   <package id="Serilog" version="1.5.14" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Uses the entirely C# version as well for better future compatibility.
Also makes an error thrown if a wrong value is attempted to be sent over
networktables.

Do not merge this until I can push NetworkTables to NuGet. Waiting on
the final native binaries from WPI.