### PR TITLE
Small modification so SmartDashboard can monitor network connection status

### DIFF
--- a/DotNetDash/MainWindow.xaml.cs
+++ b/DotNetDash/MainWindow.xaml.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using NetworkTables;
 
 namespace DotNetDash
 {
@@ -23,7 +23,13 @@ namespace DotNetDash
             }
             else
             {
-                InitializeDashboard();
+                NetworkTable.Shutdown();
+                NetworkTable.SetIPAddress($"roborio-{Properties.Settings.Default.TeamNumber}-frc.local");
+                NetworkTable.SetClientMode();
+                NetworkTable.AddConnectionListener(SetConnectivityMarker, true);
+                NetworkTable.Initialize();
+
+               InitializeDashboard();
             }
         }
 
@@ -60,20 +66,23 @@ namespace DotNetDash
         private void InitializeDashboard()
         {
             InitializeTabs();
-            InitializeConnectivityMarker();
+            //InitializeConnectivityMarker();
         }
 
-        private async void InitializeConnectivityMarker()
+        private void SetConnectivityMarker(int uid, bool connected, ConnectionInfo conn)
         {
-            await Task.Delay(500); //Add a delay to the connection check so NetworkTables can establish the connection
-            if(NetworkTables.NetworkTable.Connections().Any())
-            {
-                ConnectionIndicator.Fill = Brushes.Green;
-            }
-            else
-            {
-                ConnectionIndicator.Fill = Brushes.Red;
-            }
+            this.Dispatcher.Invoke(
+              delegate
+              {
+                  if (NetworkTables.NetworkTable.Connections().Any())
+                  {
+                      ConnectionIndicator.Fill = Brushes.Green;
+                  }
+                  else
+                  {
+                      ConnectionIndicator.Fill = Brushes.Red;
+                  }
+              }, System.Windows.Threading.DispatcherPriority.Normal);
         }
 
         private void InitializeTabs()

--- a/DotNetDash/NetworkTableBackedLookup.cs
+++ b/DotNetDash/NetworkTableBackedLookup.cs
@@ -21,11 +21,13 @@ namespace DotNetDash
         {
             get
             {
-                return (table.GetValue(key, default(T)) is T) ? (T)(table.GetValue(key, default(T))) : default(T);
+                bool success = false;
+                var value = table.GetValue(key, NetworkTables.Value.MakeValue(default(T)));
+                return (value is T) ? value.GetValue<T>(out success) : default(T);
             }
             set
             {
-                table.PutValue(key, value);
+                table.PutValue(key, NetworkTables.Value.MakeValue(value));
                 NotifyPropertyChanged(System.Windows.Data.Binding.IndexerName);
             }
         }

--- a/DotNetDash/RoboRioConnectionWindow.xaml.cs
+++ b/DotNetDash/RoboRioConnectionWindow.xaml.cs
@@ -1,5 +1,4 @@
-﻿using NetworkTables;
-using System.Windows;
+﻿using System.Windows;
 
 namespace DotNetDash
 {
@@ -15,10 +14,6 @@ namespace DotNetDash
 
         private void ConnectClicked(object sender, RoutedEventArgs e)
         {
-            NetworkTable.Shutdown();
-            NetworkTable.SetIPAddress($"roborio-{Properties.Settings.Default.TeamNumber}-frc.local");
-            NetworkTable.SetClientMode();
-            NetworkTable.Initialize();
             DialogResult = true;
             Close();
         }


### PR DESCRIPTION
Note this pull request depends on an update to robotdotnet/NetworkTables which is contained in pull request https://github.com/robotdotnet/NetworkTables/pull/38.

This pull request tweaks the SmartDashboard logic that sets the roboRio connection status icon so that it is responsive to changes in the connection status rather than relying on a single check 0.5s after the SmartDashboard starts up. 